### PR TITLE
Modify ffi build script usage of pathlib to support python 3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,10 @@ BROWSER := python -c "$$BROWSER_PYSCRIPT"
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
-clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+clean: clean-generated-ffi clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+clean-generated-ffi: ## remove FFI generated artifacts
+	rm -fr pangocffi/_generated/
 
 clean-build: ## remove build artifacts
 	rm -fr build/
@@ -57,7 +60,7 @@ lint: ## check style with flake8
 tests: ## run tests quickly with the default Python
 	python setup.py test
 
-tests-all: ## run tests on all minor python versions
+tests-all: clean ## run tests on all minor python versions
 	tox
 
 coverage: ## check code coverage quickly with the default Python

--- a/pangocffi/ffi_build.py
+++ b/pangocffi/ffi_build.py
@@ -16,9 +16,9 @@ sys.path.append(str(Path(__file__).parent))
 (Path(__file__).parent / '_generated').mkdir(exist_ok=True)
 
 # Read the CFFI definitions
-cdefs_glib_file = open(Path(__file__).parent / 'cdefs_glib.txt', 'r')
+cdefs_glib_file = open(str(Path(__file__).parent / 'cdefs_glib.txt'), 'r')
 cdefs_glib = cdefs_glib_file.read()
-cdefs_pango_file = open(Path(__file__).parent / 'cdefs_pango.txt', 'r')
+cdefs_pango_file = open(str(Path(__file__).parent / 'cdefs_pango.txt'), 'r')
 cdefs_pango = cdefs_pango_file.read()
 
 # cffi definitions, in the order outlined in:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist = py35, py36, py37
 # does not support.
 skip_install = true
 deps = pytest
+    cffi
 commands =
+    python setup.py build
     python setup.py sdist
     python setup.py test


### PR DESCRIPTION
Seamless integration between `pathlib` objects and `open()` seems to have only been implemented in  Python 3.6. https://stackoverflow.com/a/42694113

To support Python 3.5, converting the `PosixPath` to a string solves the issue.

----

Replication/proof:

```
$ echo 'hello world' >> /tmp/test.txt
$
$ python3.5
Python 3.5.6 (default, Mar  3 2019, 09:40:59) 
...
Type "help", "copyright", "credits" or "license" for more information.
>>> from pathlib import Path
>>> path = Path('/tmp/test.txt')
>>> file_handler = open(path, 'r')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: invalid file: PosixPath('/tmp/test.txt')
>>> file_handler = open(str(path), 'r')
>>> exit()
$
$ python3.6
Python 3.6.8 (default, Mar  3 2019, 08:53:45) 
...
Type "help", "copyright", "credits" or "license" for more information.
>>> from pathlib import Path
>>> path = Path('/tmp/test.txt')
>>> file_handler = open(path, 'r')
```
