### PR TITLE
Improved code coverage + minor breaking change

### DIFF
--- a/pangocffi/font_description.py
+++ b/pangocffi/font_description.py
@@ -140,14 +140,14 @@ class FontDescription(object):
         else:
             pango.pango_font_description_set_weight(self._pointer, weight)
 
-    def get_weight(self) -> Weight:
+    def get_weight(self) -> int:
         """
         Returns the weight field of a font description.
 
         :return:
             the weight field for the font description.
         """
-        return Weight(pango.pango_font_description_get_weight(self._pointer))
+        return pango.pango_font_description_get_weight(self._pointer)
 
     def set_stretch(self, stretch: Stretch) -> None:
         """

--- a/tests/functional/test_context.py
+++ b/tests/functional/test_context.py
@@ -1,16 +1,26 @@
-from pangocffi import Context, FontDescription
+from pangocffi import Context, FontDescription, ffi
+import unittest
 
 
-def test_context_init_identical_context():
-    context = Context()
-    identical_context = Context.from_pointer(context.get_pointer())
-    assert identical_context == context
+class TestContext(unittest.TestCase):
 
+    def test_context_init_identical_context(self):
+        context = Context()
+        identical_context = Context.from_pointer(context.get_pointer())
+        assert identical_context == context
 
-def test_context_properties():
-    context = Context()
+    def test_layout_not_implemented_equality(self):
+        context = Context()
+        assert ('not an object' != context)
 
-    desc = FontDescription()
-    desc.set_family('sans-serif')
-    context.set_font_description(desc)
-    assert context.get_font_description().get_family() == 'sans-serif'
+    def test_context_returns_null_from_null_pointer(self):
+        with self.assertRaises(ValueError):
+            Context.from_pointer(ffi.NULL)
+
+    def test_context_properties(self):
+        context = Context()
+
+        desc = FontDescription()
+        desc.set_family('sans-serif')
+        context.set_font_description(desc)
+        assert context.get_font_description().get_family() == 'sans-serif'

--- a/tests/functional/test_convert.py
+++ b/tests/functional/test_convert.py
@@ -1,0 +1,11 @@
+import pangocffi
+
+
+def test_units_to_double():
+    assert pangocffi.units_to_double(0) == 0
+    assert pangocffi.units_to_double(123) == 0.1201171875
+
+
+def test_context_properties():
+    assert pangocffi.units_from_double(0) == 0
+    assert pangocffi.units_from_double(0.1201171875) == 123

--- a/tests/functional/test_font_description.py
+++ b/tests/functional/test_font_description.py
@@ -1,38 +1,51 @@
 from pangocffi import FontDescription
-from pangocffi import Gravity, Stretch, Style, Variant, Weight
+from pangocffi import Gravity, Stretch, Style, Variant, Weight, ffi
+import unittest
 
 
-def test_font_description_init_identical():
-    desc = FontDescription()
-    identical_desc = desc.from_pointer(desc.get_pointer())
-    assert identical_desc == desc
+class TestFontDescription(unittest.TestCase):
 
+    def test_font_description_init_identical(self):
+        desc = FontDescription()
+        identical_desc = desc.from_pointer(desc.get_pointer())
+        assert identical_desc == desc
 
-def test_setting_properties():
-    desc = FontDescription()
+    def test_font_description_not_implemented_equality(self):
+        desc = FontDescription()
+        assert ('not an object' != desc)
 
-    desc.set_family('sans-serif')
-    assert desc.get_family() == 'sans-serif'
+    def test_font_description_returns_null_from_null_pointer(self):
+        with self.assertRaises(ValueError):
+            FontDescription.from_pointer(ffi.NULL)
 
-    desc.set_style(Style.NORMAL)
-    assert desc.get_style() == Style.NORMAL
+    def test_setting_properties(self):
+        desc = FontDescription()
 
-    desc.set_variant(Variant.NORMAL)
-    assert desc.get_variant() == Variant.NORMAL
+        assert desc.get_family() is None
+        desc.set_family('sans-serif')
+        assert desc.get_family() == 'sans-serif'
 
-    desc.set_weight(Weight.BOOK)
-    assert desc.get_weight() == Weight.BOOK
+        desc.set_style(Style.NORMAL)
+        assert desc.get_style() == Style.NORMAL
 
-    desc.set_stretch(Stretch.NORMAL)
-    assert desc.get_stretch() == Stretch.NORMAL
+        desc.set_variant(Variant.NORMAL)
+        assert desc.get_variant() == Variant.NORMAL
 
-    desc.set_size(123)
-    assert desc.get_size() == 123
-    assert not desc.get_size_is_absolute()
+        desc.set_weight(700)
+        assert desc.get_weight() == 700
+        desc.set_weight(Weight.BOOK)
+        assert desc.get_weight() == Weight.BOOK.value
 
-    desc.set_absolute_size(1.23)
-    assert desc.get_size() != 123
-    assert desc.get_size_is_absolute()
+        desc.set_stretch(Stretch.NORMAL)
+        assert desc.get_stretch() == Stretch.NORMAL
 
-    desc.set_gravity(Gravity.EAST)
-    assert desc.get_gravity() == Gravity.EAST
+        desc.set_size(123)
+        assert desc.get_size() == 123
+        assert not desc.get_size_is_absolute()
+
+        desc.set_absolute_size(1.23)
+        assert desc.get_size() != 123
+        assert desc.get_size_is_absolute()
+
+        desc.set_gravity(Gravity.EAST)
+        assert desc.get_gravity() == Gravity.EAST

--- a/tests/functional/test_layout.py
+++ b/tests/functional/test_layout.py
@@ -1,50 +1,85 @@
-from pangocffi import Context, FontDescription, Layout, Alignment
+from pangocffi import Context, FontDescription, Layout, Alignment, ffi
+import unittest
 
 
-def test_layout_returns_identical_context():
-    context = Context()
-    layout = Layout(context)
-    same_context = layout.get_context()
-    assert same_context.get_pointer() == context.get_pointer()
+class TestLayout(unittest.TestCase):
 
+    @staticmethod
+    def test_layout_returns_identical_context():
+        context = Context()
+        layout = Layout(context)
+        identical_context = layout.get_context()
+        assert identical_context.get_pointer() == context.get_pointer()
 
-def test_layout_properties():
-    context = Context()
-    layout = Layout(context)
+    @staticmethod
+    def test_layout_get_pointer_returns_identical_layout():
+        context = Context()
+        layout = Layout(context)
+        identical_layout = Layout.from_pointer(layout.get_pointer())
+        assert identical_layout.get_pointer() == layout.get_pointer()
 
-    desc = FontDescription()
-    desc.set_family('sans-serif')
-    layout.set_font_description(desc)
-    same_desc = layout.get_font_description()
-    assert same_desc.get_family() == desc.get_family()
+    def test_layout_not_implemented_equality(self):
+        context = Context()
+        layout = Layout(context)
+        assert ('not an object' != layout)
 
-    desc.set_family('serif')
-    assert same_desc.get_family() != desc.get_family()
+    def test_layout_returns_null_from_null_pointer(self):
+        with self.assertRaises(ValueError):
+            Layout.from_pointer(ffi.NULL)
 
-    layout.set_width(300)
-    assert layout.get_width() == 300
+    @staticmethod
+    def test_layout_setting_font_description():
+        context = Context()
+        layout = Layout(context)
 
-    layout.set_height(400)
-    assert layout.get_height() == 400
+        # Assert that the font description is not set
+        assert layout.get_font_description() is None
 
-    layout.set_alignment(Alignment.CENTER)
-    assert layout.get_alignment() is Alignment.CENTER
+        # Creating the font description
+        desc = FontDescription()
+        desc.set_family('sans-serif')
+        layout.set_font_description(desc)
 
-    ink_rect, logical_rect = layout.get_extents()
-    assert logical_rect.width == 0
-    assert logical_rect.height == 0
+        # Verifying the font description was set
+        same_desc = layout.get_font_description()
+        assert same_desc.get_family() == desc.get_family()
 
-    width, height = layout.get_size()
-    assert width == 0
-    assert height == 0
+        # Changing the font description
+        desc.set_family('serif')
+        assert same_desc.get_family() != desc.get_family()
 
-    # layout.set_text('hello')
-    # layout.set_markup(u'<span font="sans-serif 6">test</span>')
+        # Resetting the font description
+        layout.set_font_description(None)
+        assert layout.get_font_description() is None
 
-    width, height = layout.get_size()
-    assert width == 0
-    assert height == 0
+    @staticmethod
+    def test_layout_setting_properties():
+        context = Context()
+        layout = Layout(context)
 
-    # ink_rect, logical_rect = layout.get_extents()
-    # assert logical_rect.width == 0
-    # assert logical_rect.height == 0
+        layout.set_width(300)
+        assert layout.get_width() == 300
+
+        layout.set_height(400)
+        assert layout.get_height() == 400
+
+        layout.set_alignment(Alignment.CENTER)
+        assert layout.get_alignment() is Alignment.CENTER
+
+        ink_rect, logical_rect = layout.get_extents()
+        assert logical_rect.width == 0
+        assert logical_rect.height == 0
+
+        width, height = layout.get_size()
+        assert width == 0
+        assert height == 0
+
+    @staticmethod
+    def test_layout_setting_text():
+        context = Context()
+        layout = Layout(context)
+
+        layout.set_width(300)
+
+        layout.set_text('Hi from Pango')
+        layout.set_markup('<span font="italic 30">Hi from Παν語</span>')


### PR DESCRIPTION
`FontDescription.get_weight()` now returns an `int`, rather than the `Weight` enum. This is because it is possible to set the weight to an integer (for example, 700), rather than a specific value as part of the `Weight` enum class.

Functional tests have also been improved to cover a lot more of the code.