### PR TITLE
Only run tests once (under code coverage)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,5 @@ deps = cffi
 commands =
     python setup.py build
     python setup.py sdist
-    python setup.py test
     coverage run --source pangocffi setup.py test
     codecov


### PR DESCRIPTION
It appears tests are running twice, once with code coverage, the other without. This pull request changes that so that only tests with code coverage are run.