### PR TITLE
include pytest in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cffi >= 1.1.0
+pytest


### PR DESCRIPTION
On a fresh Python install where I've been working with venvs, I needed to install pytest in the venv for the tests to run.

Let me know what your preference for versioning in requirements.txt files is. For my own projects I tend to leave them out, like this, because I don't want to prevent updates nor set an arbitrary minimum version if I don't know of any limitations. I'll be glad to fit in with however you'd like to do it though.