### PR TITLE
small code and doc changes to install on Win64

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -20,10 +20,15 @@ pangocffi depends on Pango_, GLib_, and libffi_ being installed.
     brew install pango
     brew install glib
 
-Feel free to contribute a guide for how to install these dependencies on other
-systems.
+* On Linux, these packages are usually installed as part of the base OS.
+
+* On Windows, if you are using a 64-bit Python, you can use `this binary installer`_ to install GTK 3. Use ``python --version --version`` to check whether you're running 32-bit or 64-bit Python.
 
 .. _homebrew: https://brew.sh
+.. _`this binary installer`: https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer
+
+Feel free to contribute a guide for how to install these dependencies on other
+systems.
 
 Installing pangocffi
 ____________________

--- a/pangocffi/__init__.py
+++ b/pangocffi/__init__.py
@@ -16,8 +16,8 @@ def _dlopen(generated_ffi, *names):
     raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
 
 
-pango = _dlopen(ffi, 'pango', 'pango-1', 'pango-1.0')
-gobject = _dlopen(ffi, 'gobject-2.0')
+pango = _dlopen(ffi, 'pango', 'pango-1', 'pango-1.0', 'pango-1.0-0')
+gobject = _dlopen(ffi, 'gobject-2.0', 'gobject-2.0-0')
 
 
 # Imports are normally always put at the top of the file.

--- a/tests/functional/context_creator.py
+++ b/tests/functional/context_creator.py
@@ -4,6 +4,7 @@ from pangocffi.ffi_build import ffi as ffi_builder
 from cffi import FFI
 import ctypes
 
+
 def _dlopen(ffi, *names):
     """Try various names for the same library, for different platforms."""
     for name in names:
@@ -16,6 +17,7 @@ def _dlopen(ffi, *names):
             except OSError:
                 pass
     raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
+
 
 class ContextCreator(object):
     cairo = None
@@ -99,7 +101,8 @@ class ContextCreator(object):
             PangoContext * pango_cairo_create_context (cairo_t *cr);
         ''')
         ffi.set_source('pangocffi._generated.ffi', None)
-        cairo = _dlopen(ffi, 'cairo', 'cairo-2', 'cairo-gobject-2', 'cairo.so.2')
+        cairo = _dlopen(ffi, 'cairo', 'cairo-2', 'cairo-gobject-2', 
+            'cairo.so.2')
         pangocairo = _dlopen(ffi, 'pangocairo-1.0', 'pangocairo-1.0-0')
 
         cairo_surface_t = cairo.cairo_pdf_surface_create_for_stream(

--- a/tests/functional/context_creator.py
+++ b/tests/functional/context_creator.py
@@ -101,8 +101,8 @@ class ContextCreator(object):
             PangoContext * pango_cairo_create_context (cairo_t *cr);
         ''')
         ffi.set_source('pangocffi._generated.ffi', None)
-        cairo = _dlopen(ffi, 'cairo', 'cairo-2', 'cairo-gobject-2', 
-            'cairo.so.2')
+        cairo = _dlopen(ffi, 'cairo', 'cairo-2', 'cairo-gobject-2',
+                        'cairo.so.2')
         pangocairo = _dlopen(ffi, 'pangocairo-1.0', 'pangocairo-1.0-0')
 
         cairo_surface_t = cairo.cairo_pdf_surface_create_for_stream(

--- a/tests/functional/context_creator.py
+++ b/tests/functional/context_creator.py
@@ -2,7 +2,20 @@ import pangocffi
 from pangocffi import Context
 from pangocffi.ffi_build import ffi as ffi_builder
 from cffi import FFI
+import ctypes
 
+def _dlopen(ffi, *names):
+    """Try various names for the same library, for different platforms."""
+    for name in names:
+        for lib_name in (name, 'lib' + name):
+            try:
+                path = ctypes.util.find_library(lib_name)
+                lib = ffi.dlopen(path or lib_name)
+                if lib:
+                    return lib
+            except OSError:
+                pass
+    raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
 
 class ContextCreator(object):
     cairo = None
@@ -86,8 +99,8 @@ class ContextCreator(object):
             PangoContext * pango_cairo_create_context (cairo_t *cr);
         ''')
         ffi.set_source('pangocffi._generated.ffi', None)
-        cairo = ffi.dlopen('cairo')
-        pangocairo = ffi.dlopen('pangocairo-1.0')
+        cairo = _dlopen(ffi, 'cairo', 'cairo-2', 'cairo-gobject-2', 'cairo.so.2')
+        pangocairo = _dlopen(ffi, 'pangocairo-1.0', 'pangocairo-1.0-0')
 
         cairo_surface_t = cairo.cairo_pdf_surface_create_for_stream(
             ffi.NULL,


### PR DESCRIPTION
With these changes, after installing the GTK binaries mentioned in the doc change, I was able to run `python setup.py test` successfully, and (with another change that I'll push a PR for too), was able to run the pangocairocffi tests too and check the output, all was fine apart from the Hindi text.

I've not done much Linux testing as my Linux install is in a container and it's more of a hassle to run those tests, but I have confirmed that my own app runs correctly with the stock versions after just installing Cairo.

Let me know if there is further testing you'd like me to do to confirm that these details are correct. I have access to all three platforms, so I'm happy to check things out and make sure it's all good.