### PR TITLE
Prevent pip caching package when wheel is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+import distutils.errors
 import setuptools
 
 if sys.version_info.major < 3:
@@ -6,9 +7,29 @@ if sys.version_info.major < 3:
         'pangocffi does not support Python 2.x. Please use Python 3.'
     )
 
+"""
+Raise error if one attempts to build pangocffi as `bdist_wheel`. This is
+necessary when `wheel` is installed in the environment, because pip will
+automatically attempt to cache the package using `bdist_wheel`. By raising an
+error pip will fallback to installing as `sdist`.
+See: https://stackoverflow.com/questions/58289062/prevent-pip-from-caching-a-package
+"""
+bdist_wheel = None
+try:
+    import wheel.bdist_wheel
+
+    class bdist_wheel(wheel.bdist_wheel.bdist_wheel):
+        def run(self, *args, **kwargs):
+            raise distutils.errors.DistutilsClassError(
+                'pangocffi does not support bdist_wheel. Please use sdist.'
+            )
+except ModuleNotFoundError:
+    pass
+
 setuptools.setup(
     setup_requires=['pytest-runner'],
     cffi_modules=[
         'pangocffi/ffi_build.py:ffi'
-    ]
+    ],
+    cmdclass={'bdist_wheel': bdist_wheel}
 )


### PR DESCRIPTION
Currently `pangocffi` cannot be installed as a wheel. However package installers like pip will attempt to cache packages if the environment has `wheel` installed and will run `python setup.py bdist_wheel`. Instead, we want pip to run `python setup.py install`.

This will hopefully resolve issues raised in the `pangocairocffi` project:

* https://github.com/leifgehrmann/pangocairocffi/issues/8
* https://github.com/leifgehrmann/pangocairocffi/issues/9

To prevent wheels from being created from happening, we raise an error which should cause pip to abort caching and fallback to using `python setup.py install`.

This approach is largely inspired from these sources:

* https://stackoverflow.com/questions/58289062/prevent-pip-from-caching-a-package
* https://discuss.python.org/t/pep-517-and-projects-that-cant-install-via-wheels/791/6

I need to test first whether the pip fallback works by using https://test.pypi.org, but I have tested that an error is correctly raised when manually running `python setup.py bdist_wheel`:

```
(venv) user@virtualbox pangocffi % python setup.py bdist_wheel
running bdist_wheel
error: pangocffi does not support bdist_wheel. Please use sdist.
```