### PR TITLE
Compile FFI at runtime rather than on install

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,13 +21,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Build project
-        run: |
-          python setup.py build
-          python setup.py sdist
       - name: Generate coverage report
         run: |
-          coverage run --source pangocffi setup.py test
+          coverage run --source pangocffi -m pytest
           coverage report -m
           coverage xml
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-recursive-include pangocffi VERSION
-recursive-include pangocffi c_definitions_*.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include pangocffi VERSION
+recursive-include pangocffi c_definitions_*.txt

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -39,7 +39,7 @@ Install with pip_::
 
 .. _pip: https://pip.pypa.io/
 
-Note: Python versions < 3.5 are not supported.
+Note: Python versions < 3.6 are not supported.
 
 Importing pangocffi
 -------------------

--- a/pangocffi/__init__.py
+++ b/pangocffi/__init__.py
@@ -2,15 +2,13 @@ import ctypes.util
 from .ffi_build import ffi
 import logging
 
-fmtstr = " Name: %(user_name)s : %(asctime)s: (%(filename)s): %(levelname)s: " \
+fmtstr = "%(asctime)s: (%(filename)s): %(levelname)s: " \
          "%(funcName)s Line: %(lineno)d - %(message)s"
-datestr = "%Y-%m-%d %H:%M:%S "
 logging.basicConfig(
         filename="/tmp/pangocffi.log",
         level=logging.DEBUG,
         filemode="a",
         format=fmtstr,
-        datefmt=datestr,
     )
 logging.debug("__init__.py called from pangocffi")
 

--- a/pangocffi/__init__.py
+++ b/pangocffi/__init__.py
@@ -1,16 +1,5 @@
 import ctypes.util
 from .ffi_build import ffi
-import logging
-
-fmtstr = "%(asctime)s: (%(filename)s): %(levelname)s: " \
-         "%(funcName)s Line: %(lineno)d - %(message)s"
-logging.basicConfig(
-        filename="/tmp/pangocffi.log",
-        level=logging.DEBUG,
-        filemode="a",
-        format=fmtstr,
-    )
-logging.debug("__init__.py called from pangocffi")
 
 
 def _dlopen(generated_ffi, *names):

--- a/pangocffi/__init__.py
+++ b/pangocffi/__init__.py
@@ -1,5 +1,18 @@
 import ctypes.util
-from ._generated.ffi import ffi
+from .ffi_build import ffi
+import logging
+
+fmtstr = " Name: %(user_name)s : %(asctime)s: (%(filename)s): %(levelname)s: " \
+         "%(funcName)s Line: %(lineno)d - %(message)s"
+datestr = "%Y-%m-%d %H:%M:%S "
+logging.basicConfig(
+        filename="/tmp/pangocffi.log",
+        level=logging.DEBUG,
+        filemode="a",
+        format=fmtstr,
+        datefmt=datestr,
+    )
+logging.debug("__init__.py called from pangocffi")
 
 
 def _dlopen(generated_ffi, *names):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cffi >= 1.1.0
+flake8
 pytest
 coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
   Intended Audience :: Developers
   Natural Language :: English
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
@@ -33,7 +32,7 @@ setup_requires =
   setuptools
 install_requires =
   cffi >= 1.1.0
-python_requires = >= 3.5
+python_requires = >= 3.6
 
 [options.package_data]
 pangocffi = VERSION, *.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,9 @@ install_requires =
   cffi >= 1.1.0
 python_requires = >= 3.5
 
+[options.package_data]
+pangocffi = VERSION, *.txt
+
 [options.packages.find]
 exclude = pangocffi._generated, tests, tests.functional
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ project_urls =
 [options]
 packages = find:
 setup_requires =
-  cffi >= 1.1.0
   setuptools
 install_requires =
   cffi >= 1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ project_urls =
 
 [options]
 packages = find:
+setup_requires =
+  setuptools
 install_requires =
   cffi >= 1.1.0
 python_requires = >= 3.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,6 @@ install_requires =
   cffi >= 1.1.0
 python_requires = >= 3.5
 
-[options.package_data]
-pangocffi = VERSION, *.txt
-
 [options.packages.find]
 exclude = pangocffi._generated, tests, tests.functional
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,6 @@ project_urls =
 
 [options]
 packages = find:
-setup_requires =
-  setuptools
 install_requires =
   cffi >= 1.1.0
 python_requires = >= 3.5

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import sys
+import setuptools
 
 if sys.version_info.major < 3:
     raise RuntimeError(
         'pangocffi does not support Python 2.x. Please use Python 3.'
     )
+
+setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 import sys
-import setuptools
 
 if sys.version_info.major < 3:
     raise RuntimeError(
         'pangocffi does not support Python 2.x. Please use Python 3.'
     )
-
-setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,4 @@ if sys.version_info.major < 3:
         'pangocffi does not support Python 2.x. Please use Python 3.'
     )
 
-setuptools.setup(
-    setup_requires=['pytest-runner'],
-    cffi_modules=[
-        'pangocffi/ffi_build.py:ffi'
-    ]
-)
+setuptools.setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py35, py36, py37, py38, py39
+envlist = py36, py37, py38, py39
 
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38

--- a/tox.ini
+++ b/tox.ini
@@ -10,16 +10,8 @@ python =
     3.9: py39
 
 [testenv]
-# Skip the install because tox will want to use bdist_wheel, which pangocffi
-# does not support.
-skip_install = true
 passenv = TOXENV CI
-deps = cffi
-    flake8
-    coverage
-    pytest
+deps = -rrequirements.txt
 commands =
     flake8 pangocffi tests --exclude pangocffi/_generated/ffi.py
-    python setup.py build
-    python setup.py sdist
-    coverage run --source pangocffi setup.py test
+    coverage run --source pangocffi -m pytest


### PR DESCRIPTION
This PR changes pangocffi such that an FFI instance will be generated at runtime, rather than upon installation of the module.

This means users of this library do not need to run `python setup.py install` anymore.

This will also make libraries like pangocairocffi integrate better with pangocffi because there's a less likely chance of the FFI instances not being different. On that note though, older versions of pangocairocffi will be incompatible with pangocffi.

This change does have the drawback that an FFI will be instantiated from scratch every time a new python "session" is created. The FFI is created immedietly when `import pangocffi` occurs. Thankfully, on the machines I've tested, it doesn't take more than a second.

Other changes include:

* Dropped support for python 3.5 because the build process appears to be broken. See the "Test with tox" stage here: https://github.com/leifgehrmann/pangocffi/pull/21/checks?check_run_id=1392979164 for the full error. The error appeared to be related to the version file not complying with PEP440. It's possibly related to https://github.com/ymyzk/tox-gh-actions, but they claim to support 3.5.
* Added `flake8` to `requirements.txt` to simplify `tox.ini`
* Removed `pytest-runner` from the `setup.py` file. To run tests, just call `pytest`.
* Because we are changing the install process, `tox.ini` and `.github/workflows/coverage.yml` can be simplified, since an explicit `build`/`sdist` is no longer required.
