### PR TITLE
Adds Github Action for tests and linting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Generate coverage report
+        run: |
+          coverage run --source pangocffi -m pytest
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,9 @@ jobs:
           python setup.py sdist
       - name: Generate coverage report
         run: |
-          coverage run --source pangocffi -m pytest
+          coverage run --source pangocffi setup.py test
+          coverage report -m
+          coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Coverage
 
 on:
   push:
@@ -21,6 +21,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Build project
+        run: |
+          python setup.py build
+          python setup.py sdist
       - name: Generate coverage report
         run: |
           coverage run --source pangocffi -m pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-  - 3.7
-  - 3.6
-  - 3.5
-sudo: required
-dist: xenial
-install: pip install -U tox-travis
-script: tox

--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,14 @@ generate-cdefs: ## generate pango c definitions (requires a cloned copy of pango
 lint: ## check style with flake8
 	flake8 pangocffi tests --exclude pangocffi/_generated/ffi.py
 
-tests: ## run tests quickly with the default Python
-	python setup.py test
+test: ## run tests quickly with the default Python
+	pytest
 
-tests-all: clean ## run tests on all minor python versions
+test-all: clean ## run tests on all minor python versions
 	tox
 
 coverage: ## check code coverage quickly with the default Python
-	coverage run --source pangocffi setup.py test
+	coverage run --source pangocffi -m pytest
 	coverage report -m
 	coverage html
 	$(BROWSER) htmlcov/index.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cffi >= 1.1.0
 pytest
+coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
   Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
   Topic :: Text Processing :: Fonts
 project_urls =
   Code = https://github.com/leifgehrmann/pangocffi

--- a/tox.ini
+++ b/tox.ini
@@ -13,16 +13,13 @@ python =
 # Skip the install because tox will want to use bdist_wheel, which pangocffi
 # does not support.
 skip_install = true
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv = TOXENV CI
 deps = cffi
     flake8
     coverage
-    codecov
     pytest
 commands =
     flake8 pangocffi tests --exclude pangocffi/_generated/ffi.py
     python setup.py build
     python setup.py sdist
     coverage run --source pangocffi setup.py test
-    # Coverage results will only be sent in Travis environments
-    codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
 [tox]
-envlist = py35, py36, py37
+envlist = py35, py36, py37, py38, py39
+
+[gh-actions]
+python =
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
 
 [testenv]
 # Skip the install because tox will want to use bdist_wheel, which pangocffi
@@ -16,4 +24,5 @@ commands =
     python setup.py build
     python setup.py sdist
     coverage run --source pangocffi setup.py test
+    # Coverage results will only be sent in Travis environments
     codecov


### PR DESCRIPTION
It's unfortunate, but Travis CI has trouble running jobs during weekdays, going by their backlog: https://www.traviscistatus.com/#week

<img width="882" alt="Screenshot 2020-11-12 at 21 30 04" src="https://user-images.githubusercontent.com/3501061/98998651-69e0de00-252e-11eb-8535-fe7e41829a66.png">

Waiting several hours in the queue is not ideal.

This PR swaps out Travis CI with GitHub Actions. The following items have been checked so that they still work:

* [x] A codecov report is attached to the PR.
* [x] All python versions are tested and include code covarage results
* [x] Linting is performed in the tests.

This PR also adds 3.8 and 3.9 as test environments. I'll probably remove 3.5 once it is deprecated in January 2021.