### PR TITLE
Fix critical messages in tests

### DIFF
--- a/pangocffi/attribute.py
+++ b/pangocffi/attribute.py
@@ -107,7 +107,7 @@ class Attribute:
     #    cls, language, start_index: int = 0, end_index: int = 1
     # ) -> "Attribute":
     #    """
-    #    API not implemented
+    #    Todo: API not implemented
     #    """
     #    temp = cls._init_pointer(pango.pango_attr_language_new(language))
     #    temp.start_index = start_index

--- a/pangocffi/context.py
+++ b/pangocffi/context.py
@@ -20,10 +20,13 @@ class Context(object):
         may have it's own way of create a :class:`Context`. For instance, the
         PangoCairo toolkit has pango_cairo_create_context(). Use those instead.
         """
-        self._init_pointer(pango.pango_context_new())
+        self._init_pointer(pango.pango_context_new(), gc=True)
 
-    def _init_pointer(self, pointer: ffi.CData):
-        self._pointer = ffi.gc(pointer, gobject.g_object_unref)
+    def _init_pointer(self, pointer: ffi.CData, gc: bool):
+        if gc:
+            self._pointer = ffi.gc(pointer, gobject.g_object_unref)
+        else:
+            self._pointer = pointer
 
     def get_pointer(self) -> ffi.CData:
         """
@@ -35,17 +38,21 @@ class Context(object):
         return self._pointer
 
     @classmethod
-    def from_pointer(cls, pointer: ffi.CData) -> 'Context':
+    def from_pointer(cls, pointer: ffi.CData, gc: bool = False) -> 'Context':
         """
         Instantiates a :class:`Context` from a pointer.
 
+        :param pointer:
+            a pointer to a Pango Context.
+        :param gc:
+            whether to garbage collect the pointer. Defaults to ``False``.
         :return:
             the context.
         """
         if pointer == ffi.NULL:
             raise ValueError('Null pointer')
         self = object.__new__(cls)
-        cls._init_pointer(self, pointer)
+        cls._init_pointer(self, pointer, gc)
         return self
 
     def __eq__(self, other):

--- a/pangocffi/layout.py
+++ b/pangocffi/layout.py
@@ -23,23 +23,33 @@ class Layout(object):
         :param context:
             the Pango :class:`Context`
         """
-        self._init_pointer(pango.pango_layout_new(context.get_pointer()))
+        self._init_pointer(
+            pango.pango_layout_new(context.get_pointer()),
+            gc=True
+        )
 
-    def _init_pointer(self, pointer: ffi.CData):
-        self._pointer = ffi.gc(pointer, gobject.g_object_unref)
+    def _init_pointer(self, pointer: ffi.CData, gc: bool):
+        if gc:
+            self._pointer = ffi.gc(pointer, gobject.g_object_unref)
+        else:
+            self._pointer = pointer
 
     @classmethod
-    def from_pointer(cls, pointer: ffi.CData) -> "Layout":
+    def from_pointer(cls, pointer: ffi.CData, gc: bool = False) -> "Layout":
         """
         Instantiates a :class:`Layout` from a pointer.
 
+        :param pointer:
+            a pointer to a Pango Layout.
+        :param gc:
+            whether to garbage collect the pointer. Defaults to ``False``.
         :return:
             the layout.
         """
         if pointer == ffi.NULL:
             raise ValueError("Null pointer")
         self = object.__new__(cls)
-        cls._init_pointer(self, pointer)
+        cls._init_pointer(self, pointer, gc)
         return self
 
     def get_pointer(self) -> ffi.CData:

--- a/pangocffi/layout.py
+++ b/pangocffi/layout.py
@@ -347,7 +347,7 @@ class Layout(object):
             the layout iterator
         """
         layout_iterator_pointer = pango.pango_layout_get_iter(self._pointer)
-        return LayoutIter.from_pointer(layout_iterator_pointer)
+        return LayoutIter.from_pointer(layout_iterator_pointer, gc=True)
 
     def set_attributes(self, attrs: Optional[AttrList]) -> None:
         """

--- a/pangocffi/layout_iter.py
+++ b/pangocffi/layout_iter.py
@@ -9,8 +9,11 @@ class LayoutIter:
     Pango :class:`Layout`.
     """
 
-    def _init_pointer(self, pointer: ffi.CData):
-        self._pointer = ffi.gc(pointer, pango.pango_layout_iter_free)
+    def _init_pointer(self, pointer: ffi.CData, gc: bool):
+        if gc:
+            self._pointer = ffi.gc(pointer, pango.pango_layout_iter_free)
+        else:
+            self._pointer = pointer
 
     def get_pointer(self) -> ffi.CData:
         """
@@ -22,17 +25,25 @@ class LayoutIter:
         return self._pointer
 
     @classmethod
-    def from_pointer(cls, pointer: ffi.CData) -> 'LayoutIter':
+    def from_pointer(
+            cls,
+            pointer: ffi.CData,
+            gc: bool = False
+    ) -> 'LayoutIter':
         """
         Instantiates a :class:`LayoutIter` from a pointer.
 
+        :param pointer:
+            a pointer to a Pango Layout Iter.
+        :param gc:
+            whether to garbage collect the pointer. Defaults to ``False``.
         :return:
             the layout iterator.
         """
         if pointer == ffi.NULL:
             raise ValueError('Null pointer')
         self = object.__new__(cls)
-        cls._init_pointer(self, pointer)
+        cls._init_pointer(self, pointer, gc)
         return self
 
     def next_run(self) -> bool:

--- a/tests/functional/context_creator.py
+++ b/tests/functional/context_creator.py
@@ -2,7 +2,7 @@ import pangocffi
 from pangocffi import Context
 from pangocffi.ffi_build import ffi as ffi_builder
 from cffi import FFI
-import ctypes
+import ctypes.util
 
 
 def _dlopen(ffi, *names):
@@ -115,15 +115,14 @@ class ContextCreator(object):
 
         pango_pointer = pangocairo.pango_cairo_create_context(cairo_t)
         pango_pointer = pangocffi.ffi.cast('PangoContext *', pango_pointer)
-        pango_pointer = pangocffi.ffi.gc(
-            pango_pointer,
-            pangocffi.gobject.g_object_unref
-        )
 
         ContextCreator.cairo = cairo
         ContextCreator.cairo_surface_t = cairo_surface_t
         ContextCreator.cairo_t = cairo_t
-        ContextCreator.pango_context = Context.from_pointer(pango_pointer)
+        ContextCreator.pango_context = Context.from_pointer(
+            pango_pointer,
+            gc=True
+        )
 
         return ContextCreator.pango_context
 

--- a/tests/functional/test_attribute.py
+++ b/tests/functional/test_attribute.py
@@ -6,7 +6,7 @@ from pangocffi.rectangle import Rectangle
 from pangocffi.attribute import Attribute
 
 
-class TestLayout(unittest.TestCase):
+class TestAttribute(unittest.TestCase):
     def test_different_layout_equality(self):
         a = Attribute.from_size(4)
         b = Attribute.from_size(4)
@@ -19,7 +19,6 @@ class TestLayout(unittest.TestCase):
         b = a._pointer
         c = Attribute.from_pointer(b)
         assert a == c
-        print(type(c))
 
     def test_start_index_end_index(self):
         a = Attribute().from_size(8, 5, 9)

--- a/tests/functional/test_color.py
+++ b/tests/functional/test_color.py
@@ -4,7 +4,7 @@ import unittest
 from pangocffi import Color, ffi
 
 
-class TestLayout(unittest.TestCase):
+class TestColor(unittest.TestCase):
     def test_init(self):
         Color(5, 5, 5)
 

--- a/tests/functional/test_layout.py
+++ b/tests/functional/test_layout.py
@@ -2,10 +2,7 @@ from pangocffi import (
     Context,
     FontDescription,
     Layout,
-    Alignment,
     ffi,
-    EllipsizeMode,
-    WrapMode,
     Attribute,
     AttrList,
 )
@@ -60,44 +57,6 @@ class TestLayout(unittest.TestCase):
         # Resetting the font description
         layout.set_font_description(None)
         assert layout.get_font_description() is None
-
-    @staticmethod
-    def test_layout_setting_properties():
-        context = Context()
-        layout = Layout(context)
-
-        layout.set_width(300)
-        assert layout.get_width() == 300
-
-        layout.set_height(400)
-        assert layout.get_height() == 400
-
-        assert layout.get_spacing() == 0
-        layout.set_spacing(30)
-        assert layout.get_spacing() == 30
-
-        layout.set_alignment(Alignment.CENTER)
-        assert layout.get_alignment() is Alignment.CENTER
-
-        layout.set_ellipsize(EllipsizeMode.MIDDLE)
-        assert layout.get_ellipsize() is EllipsizeMode.MIDDLE
-
-        layout.set_wrap(WrapMode.WORD_CHAR)
-        assert layout.get_wrap() is WrapMode.WORD_CHAR
-
-        ink_rect, logical_rect = layout.get_extents()
-        assert logical_rect.width == 0
-        assert logical_rect.height == 0
-
-        width, height = layout.get_size()
-        assert width == 0
-        assert height == 0
-
-        baseline = layout.get_baseline()
-        assert baseline == 0
-
-        line_count = layout.get_line_count()
-        assert line_count == 1
 
     @staticmethod
     def test_layout_setting_text():

--- a/tests/functional/test_layout_iter.py
+++ b/tests/functional/test_layout_iter.py
@@ -1,60 +1,9 @@
-from pangocffi import Context, Layout, LayoutIter, Rectangle, ffi
+from pangocffi import LayoutIter, ffi
 import unittest
 
 
 class TestLayoutIter(unittest.TestCase):
 
-    @staticmethod
-    def test_layout_iter_pointer():
-        context = Context()
-        layout = Layout(context)
-        layout_iter = layout.get_iter()
-        assert isinstance(layout_iter.get_pointer(), ffi.CData)
-
     def test_layout_iter_returns_null_from_null_pointer(self):
         with self.assertRaises(ValueError):
             LayoutIter.from_pointer(ffi.NULL)
-
-    @staticmethod
-    def test_layout_iter_properties():
-        context = Context()
-        layout = Layout(context)
-        layout_iter = layout.get_iter()
-
-        assert layout_iter.next_run() is False
-        assert layout_iter.next_char() is False
-        assert layout_iter.next_cluster() is False
-        assert layout_iter.next_line() is False
-        assert layout_iter.at_last_line() is True
-        assert layout_iter.get_index() == 0
-        assert layout_iter.get_baseline() == 0
-
-        assert isinstance(layout_iter.get_char_extents(), Rectangle)
-
-        cluster_ink, cluster_logical = layout_iter.get_cluster_extents()
-        assert isinstance(cluster_ink, Rectangle)
-        assert isinstance(cluster_logical, Rectangle)
-
-        run_ink, run_logical = layout_iter.get_run_extents()
-        assert isinstance(run_ink, Rectangle)
-        assert isinstance(run_logical, Rectangle)
-
-        y0, y1 = layout_iter.get_line_yrange()
-        assert y0 == 0
-        assert y1 == 0
-
-        line_ink, line_logical = layout_iter.get_line_extents()
-        assert isinstance(line_ink, Rectangle)
-        assert isinstance(line_logical, Rectangle)
-
-        layout_ink, layout_logical = layout_iter.get_layout_extents()
-        assert isinstance(layout_ink, Rectangle)
-        assert isinstance(layout_logical, Rectangle)
-
-    @staticmethod
-    def test_layout_iterator_run_returns_none():
-        context = Context()
-        layout = Layout(context)
-        layout_iter = layout.get_iter()
-
-        assert layout_iter.get_run() is None

--- a/tests/functional/test_layout_iter_with_context.py
+++ b/tests/functional/test_layout_iter_with_context.py
@@ -18,6 +18,13 @@ class TestLayoutIterWithContext(unittest.TestCase):
         assert isinstance(layout_iter, LayoutIter)
         assert isinstance(layout_iter.get_pointer(), ffi.CData)
 
+        pointer_shallow_copy = layout_iter.get_pointer()
+        layout_iter_shallow_copy = LayoutIter.from_pointer(
+            pointer_shallow_copy
+        )
+        assert isinstance(layout_iter_shallow_copy, LayoutIter)
+        assert isinstance(layout_iter_shallow_copy.get_pointer(), ffi.CData)
+
     def test_layout_iter_properties(self):
         layout = Layout(self.pango_context)
         layout_iter = layout.get_iter()

--- a/tests/functional/test_layout_iter_with_context.py
+++ b/tests/functional/test_layout_iter_with_context.py
@@ -1,0 +1,63 @@
+from pangocffi import Layout, LayoutIter, Rectangle, ffi
+from .context_creator import ContextCreator
+import unittest
+
+
+class TestLayoutIterWithContext(unittest.TestCase):
+
+    def setUp(self):
+        self.pango_context = ContextCreator.get_pango_context()
+
+    def tearDown(self):
+        self.pango_context = None
+        ContextCreator.free()
+
+    def test_layout_iter_pointer(self):
+        layout = Layout(self.pango_context)
+        layout_iter = layout.get_iter()
+        assert isinstance(layout_iter, LayoutIter)
+        assert isinstance(layout_iter.get_pointer(), ffi.CData)
+
+    def test_layout_iter_properties(self):
+        layout = Layout(self.pango_context)
+        layout_iter = layout.get_iter()
+
+        assert layout_iter.next_run() is False
+        assert layout_iter.next_char() is False
+        assert layout_iter.next_cluster() is False
+        assert layout_iter.next_line() is False
+        assert layout_iter.at_last_line() is True
+        assert layout_iter.get_index() == 0
+        # Even with no text in the layout, the layout will still have a
+        # baseline corresponding to the selected font description.
+        assert layout_iter.get_baseline() > 0
+
+        assert isinstance(layout_iter.get_char_extents(), Rectangle)
+
+        cluster_ink, cluster_logical = layout_iter.get_cluster_extents()
+        assert isinstance(cluster_ink, Rectangle)
+        assert isinstance(cluster_logical, Rectangle)
+
+        run_ink, run_logical = layout_iter.get_run_extents()
+        assert isinstance(run_ink, Rectangle)
+        assert isinstance(run_logical, Rectangle)
+
+        y0, y1 = layout_iter.get_line_yrange()
+        assert y0 == 0
+        # Even with no text in the layout, the layout will still have a
+        # y-range corresponding to the selected font description.
+        assert y1 > 0
+
+        line_ink, line_logical = layout_iter.get_line_extents()
+        assert isinstance(line_ink, Rectangle)
+        assert isinstance(line_logical, Rectangle)
+
+        layout_ink, layout_logical = layout_iter.get_layout_extents()
+        assert isinstance(layout_ink, Rectangle)
+        assert isinstance(layout_logical, Rectangle)
+
+    def test_layout_iterator_run_returns_none(self):
+        layout = Layout(self.pango_context)
+        layout_iter = layout.get_iter()
+
+        assert layout_iter.get_run() is None

--- a/tests/functional/test_layout_with_context.py
+++ b/tests/functional/test_layout_with_context.py
@@ -1,4 +1,4 @@
-from pangocffi import Layout
+from pangocffi import Layout, Alignment, EllipsizeMode, WrapMode
 from .context_creator import ContextCreator
 import unittest
 
@@ -19,3 +19,45 @@ class TestLayoutWithContext(unittest.TestCase):
 
         layout.set_markup('<span font="italic 30">Hello from Παν語</span>')
         assert layout.get_text() == 'Hello from Παν語'
+
+    def test_layout_setting_properties(self):
+        layout = Layout(self.pango_context)
+
+        layout.set_width(300)
+        assert layout.get_width() == 300
+
+        layout.set_height(400)
+        assert layout.get_height() == 400
+
+        assert layout.get_spacing() == 0
+        layout.set_spacing(30)
+        assert layout.get_spacing() == 30
+
+        layout.set_alignment(Alignment.CENTER)
+        assert layout.get_alignment() is Alignment.CENTER
+
+        layout.set_ellipsize(EllipsizeMode.MIDDLE)
+        assert layout.get_ellipsize() is EllipsizeMode.MIDDLE
+
+        layout.set_wrap(WrapMode.WORD_CHAR)
+        assert layout.get_wrap() is WrapMode.WORD_CHAR
+
+        ink_rect, logical_rect = layout.get_extents()
+        assert logical_rect.width == 0
+        # The height of the layout will be the height of the font, despite no
+        # text being set against the layout.
+        assert logical_rect.height > 0
+
+        width, height = layout.get_size()
+        assert width == 0
+        # The height of the layout will be the height of the font, despite no
+        # text being set against the layout.
+        assert height > 0
+
+        baseline = layout.get_baseline()
+        # The baseline of the layout will correspond to the selected font,
+        # despite no text being set against the layout.
+        assert baseline > 0
+
+        line_count = layout.get_line_count()
+        assert line_count == 1


### PR DESCRIPTION
This resolves #35.

This was accomplished by adding a new argument `gc` to `from_pointer()` in the classes `Context`, `Layout`, and `LayoutIter`.

```py
    @classmethod
    def from_pointer(cls, pointer: ffi.CData, gc: bool = False):
        ...
```

Then in the tests:
1. Fixed `tests/functional/context_creator.py` so that it is not garbage collecting the pointer twice.
2. Moved functionality in `test_layout.py` and `test_layout_iter.py` that required using a real Pango Context into the files `test_layout_with_context.py` and `test_layout_iter_with_context.py` respectively. (This also meant changing some of the assertions in the tests, since now an actual font is being loaded. All this means is that the layouts will have a real height, baseline, and yrange that will be non-zero.)

**This change could perhaps be considered a breaking change, especially with pangocairocffi**, since before we always applied garbage collection when `from_pointer()` was called for `Context`, and `Layout` classes.

In pangocairocffi's case, it'll need to have the following methods updated so that it calls the garbage collection method directly. See https://github.com/leifgehrmann/pangocairocffi/pull/23.

I think this is an appropriate risk because I've decided that `from_pointer()` for ALL pangocffi classes should default to **not** applying a garbage collection function. This makes the behaviour more consistent across the code base. The worst case scenario is garbage collection not being applied to some pointers and potentially causes leaks. The plan is to release a new version of pangocairocffi and pangocffi at the same time to avoid this issue. This will be mentioned in the release notes of the new version.