### PR TITLE
Documentation: Remove unused code in conf.py, fix deprecated config, rearrange API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ version = ".".join(release.split(".")[:2])
 exclude_patterns = ["_build"]
 autodoc_member_order = "bysource"
 autodoc_default_options = {
-    'members': True
+    'members': None  # Set to True when readthedocs.org updates sphinx to v2.0
 }
 intersphinx_mapping = {
     "http://docs.python.org/": None,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,32 +2,6 @@ from pathlib import Path
 import sys
 import os
 
-from unittest.mock import MagicMock, Mock
-
-generated_file = Path(__file__).parent.parent / "pangocffi/_generated/ffi.py"
-if not os.path.exists(generated_file):
-
-    class AttrMock(MagicMock):
-        @classmethod
-        def __getattr__(cls, name):
-            if name in ["_mock_methods", "__qualname__", "__args__"]:
-                # noinspection PyUnresolvedReferences
-                return super.__getattr__(cls, name)
-            else:
-                mm = AttrMock()
-            mm.__repr__ = lambda s: ("pangocffi.ffi." + name)
-            mm.__str__ = Mock(return_value=("pangocffi.ffi." + name))
-            return mm
-
-    class ModuleMock(MagicMock):
-        @classmethod
-        def __getattr__(cls, name):
-            mm = AttrMock()
-            return mm
-
-    MOCK_MODULES = ["pangocffi._generated", "pangocffi._generated.ffi"]
-    sys.modules.update((mod_name, ModuleMock()) for mod_name in MOCK_MODULES)
-
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -42,7 +16,9 @@ release = release.read_text().strip()
 version = ".".join(release.split(".")[:2])
 exclude_patterns = ["_build"]
 autodoc_member_order = "bysource"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {
+    'members': True
+}
 intersphinx_mapping = {
     "http://docs.python.org/": None,
     "https://pycairo.readthedocs.io/en/latest/": None,

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -115,10 +115,6 @@ AttrList
 ________
 .. autoclass:: AttrList
 
-Underline
----------
-.. autoclass:: Underline
-
 Tab Stops
 =========
 
@@ -191,6 +187,13 @@ Language
 ________
 
 API not implemented yet.
+
+Underlined Text
+===============
+
+Enum used by Text Attributes for underlining text.
+
+.. autoclass:: Underline
 
 Bidirectional Text
 ==================


### PR DESCRIPTION
This PR does 3 things:

* Simplify the config by removing the mocking of `pangocffi._generated` and `pangocffi._generated.ffi`. This is no longer needed since we moved the generation of the FFI module to happen at runtime: #21.
* Replaced the [deprecated](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_flags) `autodoc_default_flags` configuration value to `autodoc_default_options`. Hopefully this flag still works in readthedocs.org (this will be tested before merging into master)
* Moved the Underline enum into a dedicated section in the API reference, since it didn't really make sense to bury it in Text Attributes.