### PR TITLE
Fix GitHub action for Windows + Upgrade GitHub action to use 3.10 + Fix small linting issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,36 +32,9 @@ jobs:
       - name: Install System Dependencies (Windows)
         if: runner.os == 'windows'
         run: |
-          curl -L https://github.com/naveen521kk/pango-build/releases/download/v1.50.10/pango-build-win64.zip -o pango.zip
-          7z x pango.zip -oD:\Cache
-          $env:PATH += ";" + "D:\Cache\bin"
-          # As a temporary measure, manually rename all the CORE_MANIM DLLs. I
-          # Windows' `ren` command should accept wildcards, but in practice it
-          # does not, so we have to rename them all individually.
-          ren D:\Cache\bin\CORE_MANIM_cairo-2.dll D:\Cache\bin\cairo-2.dll
-          ren D:\Cache\bin\CORE_MANIM_cairo-gobject-2.dll D:\Cache\bin\cairo-gobject-2.dll
-          ren D:\Cache\bin\CORE_MANIM_cairo-script-interpreter-2.dll D:\Cache\bin\cairo-script-interpreter-2.dll
-          ren D:\Cache\bin\CORE_MANIM_expat.dll D:\Cache\bin\expat.dll
-          ren D:\Cache\bin\CORE_MANIM_ffi-7.dll D:\Cache\bin\ffi-7.dll
-          ren D:\Cache\bin\CORE_MANIM_fontconfig-1.dll D:\Cache\bin\fontconfig-1.dll
-          ren D:\Cache\bin\CORE_MANIM_freetype-6.dll D:\Cache\bin\freetype-6.dll
-          ren D:\Cache\bin\CORE_MANIM_fribidi-0.dll D:\Cache\bin\fribidi-0.dll
-          ren D:\Cache\bin\CORE_MANIM_gio-2.0-0.dll D:\Cache\bin\gio-2.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_glib-2.0-0.dll D:\Cache\bin\glib-2.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_gmodule-2.0-0.dll D:\Cache\bin\gmodule-2.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_gobject-2.0-0.dll D:\Cache\bin\gobject-2.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_gthread-2.0-0.dll D:\Cache\bin\gthread-2.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_harfbuzz-gobject.dll D:\Cache\bin\harfbuzz-gobject.dll
-          ren D:\Cache\bin\CORE_MANIM_harfbuzz-subset.dll D:\Cache\bin\harfbuzz-subset.dll
-          ren D:\Cache\bin\CORE_MANIM_harfbuzz.dll D:\Cache\bin\harfbuzz.dll
-          ren D:\Cache\bin\CORE_MANIM_intl-8.dll D:\Cache\bin\intl-8.dll
-          ren D:\Cache\bin\CORE_MANIM_pango-1.0-0.dll D:\Cache\bin\pango-1.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_pangocairo-1.0-0.dll D:\Cache\bin\pangocairo-1.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_pangoft2-1.0-0.dll D:\Cache\bin\pangoft2-1.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_pangowin32-1.0-0.dll D:\Cache\bin\pangowin32-1.0-0.dll
-          ren D:\Cache\bin\CORE_MANIM_pixman-1-0.dll D:\Cache\bin\pixman-1-0.dll
-          ren D:\Cache\bin\CORE_MANIM_png16-16.dll D:\Cache\bin\png16-16.dll
-          ren D:\Cache\bin\CORE_MANIM_z.dll D:\Cache\bin\z.dll
-          echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          C:\msys64\usr\bin\bash -lc 'pacman -S mingw-w64-x86_64-ttf-dejavu mingw-w64-x86_64-gtk3 --noconfirm'
+          xcopy "C:\msys64\mingw64\share\fonts\TTF" "C:\Users\runneradmin\.fonts" /e /i
+          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH
+          rm C:\msys64\mingw64\bin\python.exe
       - name: Test with tox
         run: tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,33 @@ jobs:
           curl -L https://github.com/naveen521kk/pango-build/releases/download/v1.50.10/pango-build-win64.zip -o pango.zip
           7z x pango.zip -oD:\Cache
           $env:PATH += ";" + "D:\Cache\bin"
+          # As a temporary measure, manually rename all the CORE_MANIM DLLs. I
+          # Windows' `ren` command should accept wildcards, but in practice it
+          # does not, so we have to rename them all individually.
+          ren D:\Cache\bin\CORE_MANIM_cairo-2.dll D:\Cache\bin\cairo-2.dll
+          ren D:\Cache\bin\CORE_MANIM_cairo-gobject-2.dll D:\Cache\bin\cairo-gobject-2.dll
+          ren D:\Cache\bin\CORE_MANIM_cairo-script-interpreter-2.dll D:\Cache\bin\cairo-script-interpreter-2.dll
+          ren D:\Cache\bin\CORE_MANIM_expat.dll D:\Cache\bin\expat.dll
+          ren D:\Cache\bin\CORE_MANIM_ffi-7.dll D:\Cache\bin\ffi-7.dll
+          ren D:\Cache\bin\CORE_MANIM_fontconfig-1.dll D:\Cache\bin\fontconfig-1.dll
+          ren D:\Cache\bin\CORE_MANIM_freetype-6.dll D:\Cache\bin\freetype-6.dll
+          ren D:\Cache\bin\CORE_MANIM_fribidi-0.dll D:\Cache\bin\fribidi-0.dll
+          ren D:\Cache\bin\CORE_MANIM_gio-2.0-0.dll D:\Cache\bin\gio-2.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_glib-2.0-0.dll D:\Cache\bin\glib-2.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_gmodule-2.0-0.dll D:\Cache\bin\gmodule-2.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_gobject-2.0-0.dll D:\Cache\bin\gobject-2.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_gthread-2.0-0.dll D:\Cache\bin\gthread-2.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_harfbuzz-gobject.dll D:\Cache\bin\harfbuzz-gobject.dll
+          ren D:\Cache\bin\CORE_MANIM_harfbuzz-subset.dll D:\Cache\bin\harfbuzz-subset.dll
+          ren D:\Cache\bin\CORE_MANIM_harfbuzz.dll D:\Cache\bin\harfbuzz.dll
+          ren D:\Cache\bin\CORE_MANIM_intl-8.dll D:\Cache\bin\intl-8.dll
+          ren D:\Cache\bin\CORE_MANIM_pango-1.0-0.dll D:\Cache\bin\pango-1.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_pangocairo-1.0-0.dll D:\Cache\bin\pangocairo-1.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_pangoft2-1.0-0.dll D:\Cache\bin\pangoft2-1.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_pangowin32-1.0-0.dll D:\Cache\bin\pangowin32-1.0-0.dll
+          ren D:\Cache\bin\CORE_MANIM_pixman-1-0.dll D:\Cache\bin\pixman-1-0.dll
+          ren D:\Cache\bin\CORE_MANIM_png16-16.dll D:\Cache\bin\png16-16.dll
+          ren D:\Cache\bin\CORE_MANIM_z.dll D:\Cache\bin\z.dll
           echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Test with tox
         run: tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install System Dependencies (Windows)
         if: runner.os == 'windows'
         run: |
-          curl -L https://github.com/naveen521kk/pango-build/releases/download/v1.48.0/pango-build-win64.zip -o pango.zip
+          curl -L https://github.com/naveen521kk/pango-build/releases/download/v1.50.10/pango-build-win64.zip -o pango.zip
           7z x pango.zip -oD:\Cache
           $env:PATH += ";" + "D:\Cache\bin"
           echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v1

--- a/pangocffi/attr_list.py
+++ b/pangocffi/attr_list.py
@@ -118,7 +118,8 @@ class AttrList:
         pango.pango_attr_list_change(self._pointer, attr.get_pointer())
 
     def splice(self, attr_list: "AttrList", pos: int, length: int):
-        """This function opens up a hole in ``self``, fills it in with attributes
+        """
+        This function opens up a hole in ``self``, fills it in with attributes
         from the left, and then merges other on top of the hole.
         This operation is equivalent to stretching every attribute that applies
         at position pos in list by an amount len , and then calling


### PR DESCRIPTION
The `build` GitHub action is currently failing for Windows. This was probably because 7z for Windows has changed, as it failed to extract the binaries from naveen521kk's pango-build. I upgraded to the latest release, which fixed the extraction, but the latest release renamed the DLLs, and probably required more setup to install.

Rather than depending on someone else's build (that were mainly intended for the manim project), I've copied the same installation steps that pangocairocffi uses: https://github.com/leifgehrmann/pangocairocffi/blob/0490ede07f6b4e7a4cbcaec5d8ab8f66df64b475/.github/workflows/build.yml#L37

This makes the GitHub action take a few minutes more to install the dependencies, but this should be easier to maintain as pacman makes it a lot easier to manage dependencies.

Other changes:

* Upgraded the coverage GitHub action to use python 3.10.
* I also spotted a small linting issue that, I'm not actually sure how, got pushed to the master branch.

None of these changes require a new version to be released.