### PR TITLE
Split linting into a separate GitHub Action workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Coverage
+name: Lint
 
 on:
   push:
@@ -18,12 +18,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Generate coverage report
+      - name: Run linting
         run: |
-          coverage run --source pangocffi -m pytest
-          coverage report -m
-          coverage xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
+          make lint

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,4 @@ python =
 passenv = TOXENV CI
 deps = -rrequirements.txt
 commands =
-    flake8 pangocffi tests --exclude pangocffi/_generated/ffi.py
     coverage run --source pangocffi -m pytest -s


### PR DESCRIPTION
Currently there is one GitHub Action called `build.yml` that handles the linting and tests in one stage. It's a little bit annoying that linting blocks the running of tests if any of the files are not formatted correctly.

This PR splits the linting part of the workflow into `lint.yml` so that linting is executed in a separate workflow from tests.

This PR also upgrades the versions of the dependencies used in the workflows.