### PR TITLE
Added functional tests and fixed issues

### DIFF
--- a/pangocffi/context.py
+++ b/pangocffi/context.py
@@ -1,4 +1,5 @@
-from . import pango, Font, FontDescription, Gravity, GravityHint, PangoObject
+from . import pango, ffi, Font, FontDescription, Gravity, GravityHint, \
+    PangoObject
 from typing import Optional
 
 
@@ -78,14 +79,15 @@ class Context(PangoObject):
     :meth:`Gravity.EAST` or :meth:`Gravity.WEST`.
     """
 
-    def load_font(self, font_description: FontDescription) -> Font:
+    def load_font(self, font_description: FontDescription) -> Optional[Font]:
         """
         Loads a font and returns it.
 
         :param desc:
             the Pango font description.
         """
-        return Font.from_pointer(
-            pango.pango_context_load_font(self._pointer,
-                                          font_description._pointer)
-        )
+        font_pointer = pango.pango_context_load_font(self._pointer,
+                                                     font_description._pointer)
+        if font_pointer == ffi.NULL:
+            return None
+        return Font.from_pointer(font_pointer)

--- a/pangocffi/font_metrics.py
+++ b/pangocffi/font_metrics.py
@@ -9,38 +9,56 @@ class FontMetrics(PangoObject):
     _INIT_METHOD = ffi.new
     _INIT_CLASS = "PangoFontMetrics"
 
-    def approximate_char_width(self) -> int:
+    def _get_approximate_char_width(self) -> int:
         return pango.pango_font_metrics_get_approximate_char_width(
             self._pointer)
 
-    def approximate_digit_width(self) -> int:
+    approximate_char_width: int = property(_get_approximate_char_width)
+
+    def _get_approximate_digit_width(self) -> int:
         return pango.pango_font_metrics_get_approximate_digit_width(
             self._pointer)
 
-    def ascent(self) -> int:
+    approximate_digit_width: int = property(_get_approximate_digit_width)
+
+    def _get_ascent(self) -> int:
         return pango.pango_font_metrics_get_ascent(
             self._pointer)
 
-    def descent(self) -> int:
+    ascent: int = property(_get_ascent)
+
+    def _get_descent(self) -> int:
         return pango.pango_font_metrics_get_descent(
             self._pointer)
 
-    def height(self) -> int:
+    descent: int = property(_get_descent)
+
+    def _get_height(self) -> int:
         return pango.pango_font_metrics_get_height(
             self._pointer)
 
-    def strikethrough_position(self) -> int:
+    height: int = property(_get_height)
+
+    def _get_strikethrough_position(self) -> int:
         return pango.pango_font_metrics_get_strikethrough_position(
             self._pointer)
 
-    def strikethrough_thickness(self) -> int:
+    strikethrough_position: int = property(_get_strikethrough_position)
+
+    def _get_strikethrough_thickness(self) -> int:
         return pango.pango_font_metrics_get_strikethrough_thickness(
             self._pointer)
 
-    def underline_position(self) -> int:
+    strikethrough_thickness: int = property(_get_strikethrough_thickness)
+
+    def _get_underline_position(self) -> int:
         return pango.pango_font_metrics_get_underline_position(
             self._pointer)
 
-    def underline_thickness(self) -> int:
+    underline_position: int = property(_get_underline_position)
+
+    def _get_underline_thickness(self) -> int:
         return pango.pango_font_metrics_get_underline_thickness(
             self._pointer)
+
+    underline_thickness: int = property(_get_underline_thickness)

--- a/tests/functional/test_context.py
+++ b/tests/functional/test_context.py
@@ -1,5 +1,7 @@
-from pangocffi import Context, FontDescription, Gravity, GravityHint, ffi
+from pangocffi import Context, FontDescription, Gravity, GravityHint, ffi, Font
 import unittest
+
+from tests.context_creator import ContextCreator
 
 
 class TestContext(unittest.TestCase):
@@ -31,3 +33,24 @@ class TestContext(unittest.TestCase):
 
         context.gravity_hint = GravityHint.STRONG
         assert context.gravity_hint == GravityHint.STRONG
+
+    def test_context_load_font_none(self):
+        context = Context()
+
+        desc = FontDescription()
+        desc.family = 'sans-serif'
+        font = context.load_font(desc)
+        assert font is None
+
+    def test_context_load_font_with_context(self):
+        # Setup
+        surface_context = ContextCreator.create_surface_without_output()
+        context = surface_context.get_pango_context_as_class()
+
+        desc = FontDescription()
+        desc.family = 'sans-serif'
+        font = context.load_font(desc)
+        assert isinstance(font, Font)
+
+        # Tear down
+        surface_context.close()

--- a/tests/functional/test_font_metrics_with_context.py
+++ b/tests/functional/test_font_metrics_with_context.py
@@ -1,0 +1,31 @@
+from pangocffi import FontDescription, Language
+from ..context_creator import ContextCreator
+import unittest
+
+
+class TestFontMetricsWithContext(unittest.TestCase):
+
+    def setUp(self):
+        self.context = ContextCreator.create_surface_without_output()
+        self.pango_context = self.context.get_pango_context_as_class()
+
+    def tearDown(self):
+        self.pango_context = None
+        self.context.close()
+
+    def test_properties(self):
+        lang = Language.from_string('pt_BR')
+        desc = FontDescription()
+        desc.family = 'sans-serif'
+        font = self.pango_context.load_font(desc)
+        metrics = font.get_metrics(lang)
+
+        assert metrics.approximate_char_width >= 0
+        assert metrics.approximate_digit_width >= 0
+        assert metrics.ascent >= 0
+        assert metrics.descent >= 0
+        assert metrics.height >= 0
+        assert metrics.strikethrough_position >= 0
+        assert metrics.strikethrough_thickness >= 0
+        assert metrics.underline_position <= 0
+        assert metrics.underline_thickness >= 0

--- a/tests/functional/test_font_metrics_with_context.py
+++ b/tests/functional/test_font_metrics_with_context.py
@@ -27,5 +27,5 @@ class TestFontMetricsWithContext(unittest.TestCase):
         assert metrics.height >= 0
         assert metrics.strikethrough_position >= 0
         assert metrics.strikethrough_thickness >= 0
-        assert metrics.underline_position <= 0
-        assert metrics.underline_thickness >= 0
+        assert isinstance(metrics.underline_position, int)
+        assert isinstance(metrics.underline_thickness, int)

--- a/tests/functional/test_font_with_context.py
+++ b/tests/functional/test_font_with_context.py
@@ -1,0 +1,22 @@
+from pangocffi import FontDescription, Language, FontMetrics
+from ..context_creator import ContextCreator
+import unittest
+
+
+class TestFontWithContext(unittest.TestCase):
+
+    def setUp(self):
+        self.context = ContextCreator.create_surface_without_output()
+        self.pango_context = self.context.get_pango_context_as_class()
+
+    def tearDown(self):
+        self.pango_context = None
+        self.context.close()
+
+    def test_get_metrics(self):
+        lang = Language.from_string('pt_BR')
+        desc = FontDescription()
+        desc.family = 'sans-serif'
+        font = self.pango_context.load_font(desc)
+        metrics = font.get_metrics(lang)
+        assert isinstance(metrics, FontMetrics)

--- a/tests/functional/test_language.py
+++ b/tests/functional/test_language.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import patch
+
+from pangocffi import Language, ffi
+
+
+class TestLanguage(unittest.TestCase):
+
+    def test_from_string(self):
+        lang = Language.from_string('pt_BR')
+        assert isinstance(lang, Language)
+
+    def test_from_string_invalid_locale(self):
+        lang = Language.from_string(None)
+        assert lang is None
+
+    def test_default(self):
+        lang = Language.default()
+        assert isinstance(lang, Language)
+        assert isinstance(lang.to_string(), str)
+        assert len(lang.to_string()) > 0
+
+    def test_preferred_with_no_mock(self):
+        langs = Language.preferred()
+        assert langs is None or len(langs) > 0
+
+    def test_preferred_with_null_mock(self):
+        with patch(
+                'pangocffi.language.Language._pango_language_get_preferred'
+        ) as mock_func:
+            mock_func.return_value = ffi.NULL
+            langs = Language.preferred()
+            assert langs is None
+
+    def test_preferred_with_mock_list(self):
+        mock_language_a = Language.from_string('en')
+        mock_language_b = Language.from_string('de')
+        mock_langs_pointer = ffi.new("PangoLanguage*[2]", [])
+        mock_langs_pointer[0] = mock_language_a.pointer
+        mock_langs_pointer[1] = mock_language_b.pointer
+
+        with patch(
+                'pangocffi.language.Language._pango_language_get_preferred'
+        ) as mock_func:
+            mock_func.return_value = mock_langs_pointer
+            langs = Language.preferred()
+            assert langs is not None
+            assert len(langs) == 2
+            assert langs[0].to_string() == 'en'
+            assert langs[1].to_string() == 'de'
+
+    def test_matches(self):
+        lang = Language.from_string('pt_BR')
+        assert lang.matches('*')
+        assert lang.matches('pt')
+        assert lang.matches('pt;de')
+        assert lang.matches('pt:de')
+        assert lang.matches('pt,de')
+        assert lang.matches('pt-br')
+        assert lang.matches('pt_BR') is False
+        assert lang.matches('pt-de') is False
+        assert lang.matches('de') is False
+        assert lang.matches('de;se') is False
+        assert lang.matches('de:se') is False
+        assert lang.matches('de,se') is False
+
+    def test_to_string(self):
+        lang = Language.from_string('pt_BR')
+        assert lang.to_string() == 'pt-br'


### PR DESCRIPTION
* Changed FontMetrics to be pythonic: All the getter methods have been changed to properties rather than methods. e.g. `my_font_metric.approximate_char_width()` is now `my_font_metric.approximate_char_width`.
* Fixed a few issues with some of the return types:
    * `pango_context_load_font()` in some environments can return a null pointer, so I’ve changed `Context.load_font()` to return `Optional[Font]`.
    * `pango_language_from_string()` is ambiguous when a null pointer can be returned, so I’ve changed `Language.from_string()` to return `Optional[Language]`.
    * `pango_language_get_preferred()` returns an array of languages (or even a null-pointer), not a single language, so I’ve changed `Language.preferred()` to return `Optional[List['Language’]]`.
* Fixed a few internal errors:
    * Wrong parameter name for `Language.from_string()`.
    * The parameter for `Language.from_string(lang)` needed to be cast to `char[]`.
    * The parameter for `Language.matches(range_list)` needed to be cast to `char[]`.
    * The return value for `Language.to_string()` needed to be decoded to utf-8.
* Added functional tests for `Context`, `FontMetrics`, `Font`, `Language`.
    * A special function `_pango_language_get_preferred` was added to `Language` to mock one of pango’s methods.