### PR TITLE
Deprecate Python 3.8 and 3.9 + Skip adding fonts tests on macOS + Support Windows test environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -56,7 +56,7 @@ Install with pip_::
 
 .. _pip: https://pip.pypa.io/
 
-Note: Python versions < 3.8 are not supported.
+Note: Python versions < 3.10 are not supported.
 
 Importing pangocffi
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,11 +17,11 @@ classifiers =
   Intended Audience :: Developers
   Natural Language :: English
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.8
-  Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
+  Programming Language :: Python :: 3.13
+  Programming Language :: Python :: 3.14
   Topic :: Text Processing :: Fonts
 project_urls =
   Code = https://github.com/leifgehrmann/pangocffi
@@ -33,7 +33,7 @@ setup_requires =
   setuptools
 install_requires =
   cffi >= 1.1.0
-python_requires = >= 3.8
+python_requires = >= 3.10
 
 [options.package_data]
 pangocffi = VERSION, *.txt

--- a/tests/functional/test_add_font_file.py
+++ b/tests/functional/test_add_font_file.py
@@ -46,10 +46,9 @@ def test_pango_font_map_add_font_file_error():
 
     with pytest.raises(ValueError) as e:
         _pango_font_map_add_font_file(fontmap, "/not/a/font/filename.xxx")
-    assert e.match(r"Adding.* /not/a/font/filename.xxx .*failed") or \
-        e.match(
-            r"Specified font file '/not/a/font/filename.xxx' does not exist"
-        )
+    assert e.match(
+        r"(Adding.* /not/a/font/filename.xxx .*failed)|"
+        r"(Specified font file '/not/a/font/filename.xxx' does not exist)")
 
 
 def _pango_font_map_add_font_file(fontmap: PangoFontMap_ptr, filename: str):

--- a/tests/functional/test_add_font_file.py
+++ b/tests/functional/test_add_font_file.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from typing import Any, TypeAlias
 
@@ -14,11 +15,18 @@ needs_pango_156 = pytest.mark.skipif(
 )
 
 
+skip_macos = pytest.mark.skipif(
+    sys.platform == 'darwin',
+    reason="Adding font files not supported for PangoCairoCoreTextFontMap"
+)
+
+
 TEST_FONT_PATH = Path(__file__).parent / "Untitled1.ttf"
 TEST_FONT_FAMILY_NAME = "Untitled1"
 
 
 @needs_pango_156
+@skip_macos
 def test_pango_font_map_add_font_file():
     context_creator = ContextCreator.create_surface_without_output()
     fontmap = context_creator.pangocairo.pango_cairo_font_map_new()
@@ -31,6 +39,7 @@ def test_pango_font_map_add_font_file():
 
 
 @needs_pango_156
+@skip_macos
 def test_pango_font_map_add_font_file_error():
     context_creator = ContextCreator.create_surface_without_output()
     fontmap = context_creator.pangocairo.pango_cairo_font_map_new()

--- a/tests/functional/test_add_font_file.py
+++ b/tests/functional/test_add_font_file.py
@@ -53,7 +53,7 @@ def test_pango_font_map_add_font_file_error():
 
 
 @pytest.mark.skipif(
-    sys.platform == 'darwin',
+    sys.platform != 'darwin',
     reason="applies only to macOS"
 )
 def test_pango_font_map_add_font_file_errors_on_core_text():

--- a/tests/functional/test_add_font_file.py
+++ b/tests/functional/test_add_font_file.py
@@ -46,7 +46,10 @@ def test_pango_font_map_add_font_file_error():
 
     with pytest.raises(ValueError) as e:
         _pango_font_map_add_font_file(fontmap, "/not/a/font/filename.xxx")
-    assert e.match(r"Adding.* /not/a/font/filename.xxx .*failed")
+    assert e.match(r"Adding.* /not/a/font/filename.xxx .*failed") or \
+        e.match(
+            r"Specified font file '/not/a/font/filename.xxx' does not exist"
+        )
 
 
 def _pango_font_map_add_font_file(fontmap: PangoFontMap_ptr, filename: str):

--- a/tests/functional/test_add_font_file.py
+++ b/tests/functional/test_add_font_file.py
@@ -46,6 +46,7 @@ def test_pango_font_map_add_font_file_error():
 
     with pytest.raises(ValueError) as e:
         _pango_font_map_add_font_file(fontmap, "/not/a/font/filename.xxx")
+    # Linux and Windows return these errors, respectively
     assert e.match(
         r"(Adding.* /not/a/font/filename.xxx .*failed)|"
         r"(Specified font file '/not/a/font/filename.xxx' does not exist)")

--- a/tests/functional/test_add_font_file.py
+++ b/tests/functional/test_add_font_file.py
@@ -52,6 +52,21 @@ def test_pango_font_map_add_font_file_error():
         r"(Specified font file '/not/a/font/filename.xxx' does not exist)")
 
 
+@pytest.mark.skipif(
+    sys.platform == 'darwin',
+    reason="applies only to macOS"
+)
+def test_pango_font_map_add_font_file_errors_on_core_text():
+    context_creator = ContextCreator.create_surface_without_output()
+    fontmap = context_creator.pangocairo.pango_cairo_font_map_new()
+
+    with pytest.raises(ValueError) as e:
+        _pango_font_map_add_font_file(fontmap, str(TEST_FONT_PATH))
+    assert e.match(
+        r"Adding font files not supported for PangoCairoCoreTextFontMap"
+    )
+
+
 def _pango_font_map_add_font_file(fontmap: PangoFontMap_ptr, filename: str):
     filename = ffi.new("char[]", filename.encode())
     error = ffi.new("GError**")

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py38, py39, py310, py311, py312
+envlist = py310, py311, py312, py313, py314
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py3120
+    3.13: py313
+    3.14: py314
 
 [testenv]
 passenv = TOXENV,CI


### PR DESCRIPTION
This PR addresses some of the test environment issues from #62:

1. Python versions 3.8 and 3.9 are both [end-of-life](https://devguide.python.org/versions/), so support for those versions have been dropped, and the test environments have been replaced with newer versions of Python, 3.13 and 3.14.

2. On Windows test environments, the error for font file errors is different from Linux. `Specified font file '/not/a/font/filename.xxx' does not exist` as opposed to `Adding.* /not/a/font/filename.xxx .*failed`. So the `e.match()` assertion has been updated to support both.

3. Tests for macOS are failing because the error "Adding font files not supported for PangoCairoCoreTextFontMap" is raised when calling `pango_font_map_add_font_file`. These tests will be skipped, and a new test for just macOS has been added that assert the error is thrown.